### PR TITLE
docs: Use git-branch-stack-cli in cargo install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Backup and restore what your branches, including what they point at.
 
 Or use rust to install:
 ```bash
-cargo install git-branch-stash
+cargo install git-branch-stash-cli
 ```
 
 ### Uninstall


### PR DESCRIPTION
The name of the CLI package is `git-branch-stack-cli`. Invoking `cargo install git-branch-stack` leads to a cargo error about the package not being a binary.